### PR TITLE
Make configuration fop 2.1 compatible

### DIFF
--- a/xml/rosbot/fop.conf
+++ b/xml/rosbot/fop.conf
@@ -13,10 +13,8 @@ the location of this file.
 -->
 
 <!-- NOTE: This is the version of the configuration -->
-<fop version="1.0">
+<fop version="1.1">
 
-  <!-- Base URL for resolving relative URLs -->
-  <base>.</base>
   <font-base>.</font-base>
   <!-- Source resolution in dpi (dots/pixels per inch) for determining the size of pixels in SVG and bitmap images, default: 72dpi -->
   <source-resolution>72</source-resolution>
@@ -24,7 +22,7 @@ the location of this file.
   <target-resolution>72</target-resolution>
   
   <!-- Default page-height and page-width, in case value is specified as auto -->
-  <default-page-settings height="11.00in" width="8.50in"/>
+  <default-page-settings height="29.7cm" width="21cm"/>
   
   <!-- Information for specific renderers -->
   <!-- Uses renderer mime type for renderers -->
@@ -81,7 +79,7 @@ the location of this file.
         <!--
         <directory recursive="true">/Library/Fonts/</directory>
         -->
-        <font kerning="yes" embed-url="LiberationSansNarrow-Regular-webfont.ttf">
+        <font kerning="yes" embed-url="LiberationSansNarrow-Regular.ttf">
           <font-triplet name="LiberationSansNarrow" style="normal" weight="normal"/>
         </font>
         <font kerning="yes" embed-url="LiberationSansNarrow-Bold.ttf">


### PR DESCRIPTION
Note that the change is backwards compatible with fop < 2.1

Changed dimensions to European A4 format (as specified in the README).
Changed normal font to regular (non-webfont).
